### PR TITLE
Adding support for bitcoind "generate" category.  

### DIFF
--- a/bitcoin_gains.py
+++ b/bitcoin_gains.py
@@ -108,7 +108,7 @@ class BitcoindParser(TransactionParser):
                 account = 'bitcoind'
             if item['category'] == 'receive':
                 yield Transaction(timestamp, 'deposit', item['amount'], 0, 0, id=item['txid'], info=info, account=account)
-            if item['category'] == 'generate':
+            elif item['category'] == 'generate':
                 yield Transaction(timestamp, 'deposit', item['amount'], 0, 0, id=item['txid'], info=info, account=account)
             elif item['category'] == 'send':
                 yield Transaction(timestamp, 'withdraw', item['amount'], 0, 0, fee_btc=item.get('fee', 0), id=item['txid'], info=info, account=account)

--- a/bitcoin_gains.py
+++ b/bitcoin_gains.py
@@ -108,6 +108,8 @@ class BitcoindParser(TransactionParser):
                 account = 'bitcoind'
             if item['category'] == 'receive':
                 yield Transaction(timestamp, 'deposit', item['amount'], 0, 0, id=item['txid'], info=info, account=account)
+            if item['category'] == 'generate':
+                yield Transaction(timestamp, 'deposit', item['amount'], 0, 0, id=item['txid'], info=info, account=account)
             elif item['category'] == 'send':
                 yield Transaction(timestamp, 'withdraw', item['amount'], 0, 0, fee_btc=item.get('fee', 0), id=item['txid'], info=info, account=account)
             elif item['category'] == 'move' and item['amount'] < 0 and not parsed_args.consolidate_bitcoind:


### PR DESCRIPTION
This change adds support for the bitcoind "generate" category. The generate category is used when bitcoind receives freshly minted bitcoins either from solo miners or pools that transfer the bitcoins to the pool members right in the block they sign.
