### PR TITLE
Skip conflicted transactions from Bitcoin Core

### DIFF
--- a/bitcoin_gains.py
+++ b/bitcoin_gains.py
@@ -118,6 +118,10 @@ class BitcoindParser(TransactionParser):
                 account = ('bitcoind-%s' % item['account']).strip('-')
             else:
                 account = 'bitcoind'
+            confirmations = item['confirmations']
+            # Negative confirmations indicate a conflicted transaction.
+            if confirmations < 0:
+                continue
             if item['category'] == 'receive':
                 yield Transaction(timestamp, 'deposit', item['amount'], 0, 0, id=item['txid'], info=info, account=account)
             elif item['category'] == 'generate':


### PR DESCRIPTION
Conflicted transactions (transactions that aren't in the longest chain and which conflict with a transaction that is in the longest chain; they commonly show up if a fee was bumped via RBF) shouldn't be counted.