### PR TITLE
Fix default fmv_url

### DIFF
--- a/bitcoin_gains.py
+++ b/bitcoin_gains.py
@@ -47,7 +47,7 @@ parser.add_argument('histories', metavar='FILE', nargs='+',
 parser.add_argument('--fmv_url', dest='fmv_urls',
                     action='append',
                     default=[
-                        'https://blockchain.info/charts/market-price?timespan=all&daysAverageString=1&format=csv',
+                        'https://api.blockchain.info/charts/market-price?timespan=all&daysAverageString=1&format=csv',
                     ],
                     help='fair market value prices urls')
 


### PR DESCRIPTION
Blockchain.info no longer allows API access without the `api.` subdomain.